### PR TITLE
Add simple brand site skeleton

### DIFF
--- a/drake-inspired/README.md
+++ b/drake-inspired/README.md
@@ -1,0 +1,10 @@
+# Drake Inspired Site Skeleton
+
+This folder contains a minimal HTML and CSS example for a brand store design similar to modern merchandise sites. The layout includes:
+
+- A top navigation bar with links
+- A hero section with a large banner image
+- A simple product grid
+- A footer with copyright text
+
+To preview the site, open `index.html` in your web browser. The images referenced in the HTML (e.g., `hero-placeholder.jpg`) are placeholders—you can replace them with your own product photos.

--- a/drake-inspired/index.html
+++ b/drake-inspired/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>SkyyRose Brand Store</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1>SkyyRose</h1>
+      <nav>
+        <a href="#">Home</a>
+        <a href="#">Shop</a>
+        <a href="#">About</a>
+        <a href="#">Contact</a>
+      </nav>
+    </div>
+  </header>
+  <section class="hero">
+    <div class="container">
+      <h2>Welcome to our store</h2>
+      <p>Latest collection available now</p>
+    </div>
+  </section>
+  <section class="products">
+    <div class="container">
+      <div class="product">
+        <img src="placeholder1.jpg" alt="Product 1">
+        <h3>Product 1</h3>
+        <p>$29.99</p>
+      </div>
+      <div class="product">
+        <img src="placeholder2.jpg" alt="Product 2">
+        <h3>Product 2</h3>
+        <p>$39.99</p>
+      </div>
+    </div>
+  </section>
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 SkyyRose LLC</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/drake-inspired/styles.css
+++ b/drake-inspired/styles.css
@@ -1,0 +1,48 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+header {
+  background: #000;
+  color: #fff;
+  padding: 10px 0;
+}
+header .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 15px;
+}
+header nav a {
+  color: #fff;
+  margin-left: 15px;
+  text-decoration: none;
+}
+.hero {
+  background-image: url('hero-placeholder.jpg');
+  background-size: cover;
+  background-position: center;
+  color: #fff;
+  padding: 100px 0;
+  text-align: center;
+}
+.products {
+  padding: 50px 0;
+}
+.products .product {
+  display: inline-block;
+  margin: 0 15px;
+  text-align: center;
+}
+.product img {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+}
+footer {
+  background: #f1f1f1;
+  padding: 20px 0;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add minimal HTML and CSS for a brand store layout
- document how to preview the example site

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b6f64215c832d8108860bcabc7c17